### PR TITLE
remove go func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.15
 require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.1.0 // indirect
-
 	github.com/sirupsen/logrus v1.8.1
-
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 )


### PR DESCRIPTION
rip out all to concurrency stuff, because a) it didn't work and b) we're hitting rate limitting if it actually works

this also adds log formatting as json for easy consumption and a `debug` flag